### PR TITLE
ベースイメージの更新(GLIBC互換性の問題)

### DIFF
--- a/docker/y-sweet.Dockerfile
+++ b/docker/y-sweet.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev && \
     cargo build --release
 
 # ---------- Runtime Stage ----------
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
GLIBC互換性: より新しいGLIBCバージョンを使用