### PR TITLE
ydocをcopyするapiの実装

### DIFF
--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -105,6 +105,25 @@ pub struct DocCreationRequest {
     pub doc_id: Option<String>,
 }
 
+#[derive(Deserialize)]
+pub struct DocCopyRequest {
+    /// The ID of the destination document where the source document will be copied to
+    #[serde(rename = "destinationDocId")]
+    pub destination_doc_id: String,
+}
+
+#[derive(Serialize)]
+pub struct DocCopyResponse {
+    /// The ID of the source document that was copied
+    #[serde(rename = "sourceDocId")]
+    pub source_doc_id: String,
+    /// The ID of the destination document where the copy was created
+    #[serde(rename = "destinationDocId")]
+    pub destination_doc_id: String,
+    /// Whether the copy operation was successful
+    pub success: bool,
+}
+
 /// Validate that the document name contains only alphanumeric characters, dashes, and underscores.
 /// This is the same alphabet used by nanoid when we generate a document name.
 pub fn validate_doc_name(doc_name: &str) -> bool {

--- a/crates/y-sweet-core/src/store/mod.rs
+++ b/crates/y-sweet-core/src/store/mod.rs
@@ -28,6 +28,7 @@ pub trait Store: 'static {
     async fn generate_upload_presigned_url(&self, key: &str) -> Result<String>;
     async fn generate_download_presigned_url(&self, key: &str) -> Result<String>;
     async fn list_objects(&self, prefix: &str) -> Result<Vec<String>>;
+    async fn copy_document(&self, source_doc_id: &str, destination_doc_id: &str) -> Result<()>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -41,4 +42,5 @@ pub trait Store: Send + Sync {
     async fn generate_upload_presigned_url(&self, key: &str) -> Result<String>;
     async fn generate_download_presigned_url(&self, key: &str) -> Result<String>;
     async fn list_objects(&self, prefix: &str) -> Result<Vec<String>>;
+    async fn copy_document(&self, source_doc_id: &str, destination_doc_id: &str) -> Result<()>;
 }


### PR DESCRIPTION
## Proposed Changes

- ydocをcopyするapiの実装をしましtあ

assetsも含めてコピーするように実装しています

## Implementation

```sh
curl -X 'POST' -d '{"destinationDocId":"copy-test"}' -H 'Authorization: Bearer AAAg0NFB57WWjaDZUh3vFSEepBH843FsU9qER96Ic71Sfj4' -H 'Content-Type: application/json' 'http://localhost:8080/d/1234567890/copy'
```

```json
{"sourceDocId":"1234567890","destinationDocId":"copy-test","success":true}
```
