### PR TITLE
feat: tag ws spans with doc_id and switch /metrics to OpenMetrics

### DIFF
--- a/crates/y-sweet-core/src/api_types_ext.rs
+++ b/crates/y-sweet-core/src/api_types_ext.rs
@@ -75,27 +75,3 @@ pub struct DocDeleteResponse {
     /// Indicates that the delete operation completed without errors.
     pub success: bool,
 }
-
-/// Per-document metrics
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DocMetrics {
-    /// The document ID
-    pub doc_id: String,
-    /// Number of awareness protocol clients
-    pub awareness_clients: usize,
-    /// Number of active WebSocket connections
-    pub connections: usize,
-    /// Document byte size (sum of sync_kv keys and values)
-    pub size_bytes: usize,
-}
-
-/// Server-wide metrics snapshot for capacity planning
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MetricsResponse {
-    /// Number of currently loaded documents
-    pub loaded_docs: usize,
-    /// Per-document metrics
-    pub docs: Vec<DocMetrics>,
-}

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -34,6 +34,7 @@ pub struct DocConnection {
     authorization: Authorization,
     callback: Callback,
     closed: Arc<OnceLock<()>>,
+    doc_id: String,
 
     /// If the client sends an awareness state, this will be set to its client ID.
     /// It is used to clear the awareness state when a client disconnects.
@@ -43,6 +44,7 @@ pub struct DocConnection {
 impl DocConnection {
     #[cfg(not(feature = "sync"))]
     pub fn new<F>(
+        doc_id: String,
         awareness: Arc<RwLock<Awareness>>,
         authorization: Authorization,
         callback: F,
@@ -50,11 +52,12 @@ impl DocConnection {
     where
         F: Fn(&[u8]) + 'static,
     {
-        Self::new_inner(awareness, authorization, Arc::new(callback))
+        Self::new_inner(doc_id, awareness, authorization, Arc::new(callback))
     }
 
     #[cfg(feature = "sync")]
     pub fn new<F>(
+        doc_id: String,
         awareness: Arc<RwLock<Awareness>>,
         authorization: Authorization,
         callback: F,
@@ -62,10 +65,11 @@ impl DocConnection {
     where
         F: Fn(&[u8]) + 'static + Send + Sync,
     {
-        Self::new_inner(awareness, authorization, Arc::new(callback))
+        Self::new_inner(doc_id, awareness, authorization, Arc::new(callback))
     }
 
     pub fn new_inner(
+        doc_id: String,
         awareness: Arc<RwLock<Awareness>>,
         authorization: Authorization,
         callback: Callback,
@@ -79,7 +83,7 @@ impl DocConnection {
             // https://github.com/y-crdt/y-sync/blob/56958e83acfd1f3c09f5dd67cf23c9c72f000707/src/sync.rs#L45-L54
 
             {
-                let span = tracing::info_span!("ws.initial_sync");
+                let span = tracing::info_span!("ws.initial_sync", doc_id = %doc_id);
                 let _guard = span.enter();
 
                 {
@@ -150,12 +154,14 @@ impl DocConnection {
             callback,
             client_id: OnceLock::new(),
             closed,
+            doc_id,
         }
     }
 
     pub async fn send(&self, update: &[u8]) -> Result<(), anyhow::Error> {
         let span = tracing::info_span!(
             "ws.message.process",
+            doc_id = %self.doc_id,
             message_type = tracing::field::Empty,
             payload_size = update.len(),
         );

--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -177,16 +177,21 @@ async fn websocket_connect(req: Request, ctx: RouteContext<&mut YServe>) -> Resu
 
     let connection = {
         let server = server.clone();
-        DocConnection::new(doc_id.clone(), awareness, Authorization::Full, move |bytes| {
-            let uint8_array = Uint8Array::from(bytes);
-            let result = server
-                .as_ref()
-                .send_with_array_buffer(&uint8_array.buffer());
+        DocConnection::new(
+            doc_id.clone(),
+            awareness,
+            Authorization::Full,
+            move |bytes| {
+                let uint8_array = Uint8Array::from(bytes);
+                let result = server
+                    .as_ref()
+                    .send_with_array_buffer(&uint8_array.buffer());
 
-            if let Err(result) = result {
-                console_log!("Error sending bytes: {:?}", result);
-            }
-        })
+                if let Err(result) = result {
+                    console_log!("Error sending bytes: {:?}", result);
+                }
+            },
+        )
     };
 
     wasm_bindgen_futures::spawn_local(async move {

--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -177,7 +177,7 @@ async fn websocket_connect(req: Request, ctx: RouteContext<&mut YServe>) -> Resu
 
     let connection = {
         let server = server.clone();
-        DocConnection::new(awareness, Authorization::Full, move |bytes| {
+        DocConnection::new(doc_id.clone(), awareness, Authorization::Full, move |bytes| {
             let uint8_array = Uint8Array::from(bytes);
             let result = server
                 .as_ref()

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -777,6 +777,7 @@ async fn handle_socket_upgrade(
         let span = tracing::info_span!("ws.session", doc_id = %doc_id);
         handle_socket(
             socket,
+            doc_id,
             awareness,
             connection_count,
             authorization,
@@ -846,6 +847,7 @@ impl Drop for ConnectionGuard {
 
 async fn handle_socket(
     socket: WebSocket,
+    doc_id: String,
     awareness: Arc<RwLock<Awareness>>,
     connection_count: Arc<AtomicUsize>,
     authorization: Authorization,
@@ -909,7 +911,7 @@ async fn handle_socket(
         }
     });
 
-    let connection = DocConnection::new(awareness, authorization, move |bytes| {
+    let connection = DocConnection::new(doc_id, awareness, authorization, move |bytes| {
         if let Err(e) = send.try_send(bytes.to_vec()) {
             let error_message = format!("WebSocket message error: {}", e);
             warn!(

--- a/crates/y-sweet/src/server_ext.rs
+++ b/crates/y-sweet/src/server_ext.rs
@@ -14,7 +14,7 @@ use y_sweet_core::{
     api_types::validate_doc_name,
     api_types_ext::{
         AssetUrl, AssetsResponse, ContentUploadRequest, ContentUploadResponse, DocCopyRequest,
-        DocCopyResponse, DocDeleteResponse, DocMetrics, MetricsResponse,
+        DocCopyResponse, DocDeleteResponse,
     },
     store::StoreError,
 };
@@ -480,30 +480,82 @@ pub async fn copy_document(
     }
 }
 
-/// GET /metrics — JSON metrics endpoint for capacity planning (no auth required)
-pub async fn metrics_handler(State(server): State<Arc<Server>>) -> Json<MetricsResponse> {
-    let docs: Vec<DocMetrics> = server
+/// GET /metrics — OpenMetrics endpoint for capacity planning (no auth required)
+pub async fn metrics_handler(State(server): State<Arc<Server>>) -> impl IntoResponse {
+    struct DocSample {
+        doc_id_label: String,
+        connections: usize,
+        awareness_clients: usize,
+        size_bytes: usize,
+    }
+
+    let samples: Vec<DocSample> = server
         .docs
         .iter()
         .map(|entry| {
             let dwskv = entry.value();
+            let doc_id_label = entry
+                .key()
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n");
             let awareness_clients = {
                 let aw = dwskv.awareness();
                 let g = aw.read().unwrap();
                 g.clients().len()
             };
-            DocMetrics {
-                doc_id: entry.key().clone(),
-                awareness_clients,
+            DocSample {
+                doc_id_label,
                 connections: dwskv.connection_count().load(Ordering::Relaxed),
+                awareness_clients,
                 size_bytes: dwskv.sync_kv().byte_size(),
             }
         })
         .collect();
-    Json(MetricsResponse {
-        loaded_docs: server.docs.len(),
-        docs,
-    })
+
+    let mut body = String::new();
+
+    body.push_str("# HELP ysweet_loaded_docs Number of currently loaded documents.\n");
+    body.push_str("# TYPE ysweet_loaded_docs gauge\n");
+    body.push_str(&format!("ysweet_loaded_docs {}\n", server.docs.len()));
+
+    body.push_str("# HELP ysweet_doc_connections Active WebSocket connections per document.\n");
+    body.push_str("# TYPE ysweet_doc_connections gauge\n");
+    for s in &samples {
+        body.push_str(&format!(
+            "ysweet_doc_connections{{doc_id=\"{}\"}} {}\n",
+            s.doc_id_label, s.connections
+        ));
+    }
+
+    body.push_str("# HELP ysweet_doc_awareness_clients Awareness clients per document.\n");
+    body.push_str("# TYPE ysweet_doc_awareness_clients gauge\n");
+    for s in &samples {
+        body.push_str(&format!(
+            "ysweet_doc_awareness_clients{{doc_id=\"{}\"}} {}\n",
+            s.doc_id_label, s.awareness_clients
+        ));
+    }
+
+    body.push_str("# HELP ysweet_doc_size_bytes SyncKV byte size per document.\n");
+    body.push_str("# TYPE ysweet_doc_size_bytes gauge\n");
+    for s in &samples {
+        body.push_str(&format!(
+            "ysweet_doc_size_bytes{{doc_id=\"{}\"}} {}\n",
+            s.doc_id_label, s.size_bytes
+        ));
+    }
+
+    body.push_str("# EOF\n");
+
+    (
+        axum::http::StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )],
+        body,
+    )
 }
 
 /// Extension routes for custom endpoints


### PR DESCRIPTION
## Summary

- **`ws.initial_sync` / `ws.message.process` spans now carry `doc_id` tag directly.**
  Previously `doc_id` was only set on the parent `ws.session` span, and Datadog does not propagate span tags from parent to child. This meant neither child span was individually filterable by `doc_id` in APM. The fix threads `doc_id` through `DocConnection` (new struct field + constructor parameter) so each span records it at creation time.

- **`GET /metrics` now returns OpenMetrics text format** (`Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8`) instead of JSON, enabling automatic scraping by `dd_agent` via its OpenMetrics check. The exposition follows the standard HELP/TYPE/samples structure with `doc_id` label and ends with `# EOF`.

- Removed the now-unused `DocMetrics` / `MetricsResponse` serde types from `api_types_ext`.

## Changed files

| File | Change |
|------|--------|
| `y-sweet-core/src/doc_connection.rs` | Add `doc_id` field + ctor param; tag `ws.initial_sync` and `ws.message.process` spans |
| `y-sweet/src/server.rs` | Pass `doc_id` to `handle_socket` and `DocConnection::new` |
| `y-sweet-worker/src/durable_object.rs` | Pass `doc_id` to `DocConnection::new` |
| `y-sweet/src/server_ext.rs` | Rewrite `metrics_handler` to emit OpenMetrics exposition |
| `y-sweet-core/src/api_types_ext.rs` | Remove unused `DocMetrics` / `MetricsResponse` |

## Test plan

- [ ] `cargo build --all` passes ✅
- [ ] `cargo test --all` passes (33 tests) ✅
- [ ] `cargo fmt -- --check` passes ✅
- [ ] In Datadog APM, filter spans by `doc_id:<value>` on `ws.initial_sync` and `ws.message.process` — both should return results immediately when a WS connection is made
- [ ] `curl -i http://localhost:<port>/metrics` returns `Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8` with body ending in `# EOF`
- [ ] Configure `dd_agent` OpenMetrics check pointing at the endpoint and confirm metrics ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)