### PR TITLE
feat: limit /metrics doc-level output to top 10 by connection count

### DIFF
--- a/crates/y-sweet/src/server_ext.rs
+++ b/crates/y-sweet/src/server_ext.rs
@@ -513,6 +513,10 @@ pub async fn metrics_handler(State(server): State<Arc<Server>>) -> impl IntoResp
         })
         .collect();
 
+    let mut samples = samples;
+    samples.sort_by(|a, b| b.connections.cmp(&a.connections));
+    samples.truncate(10);
+
     let mut body = String::new();
 
     body.push_str("# HELP ysweet_loaded_docs Number of currently loaded documents.\n");


### PR DESCRIPTION
## Summary

- `/metrics` の `doc_id` タグ付きメトリクス（`ysweet_doc_connections`, `ysweet_doc_awareness_clients`, `ysweet_doc_size_bytes`）をコネクション数降順でソートし、上位10件のみ出力するよう変更
- `ysweet_loaded_docs`（`doc_id` タグなし、全ドキュメント数）は変更なし

## Background

Datadog のカスタムメトリクスはメトリクス × タグ値の組み合わせ単位で課金される。`doc_id` のカーディナリティが高いため、全件出力するとコストが膨大になる問題に対応。

## Test plan

- [ ] `cargo build --all` が通ること
- [ ] `cargo test --all` が通ること
- [ ] `cargo fmt -- --check` が通ること
- [ ] `/metrics` レスポンスに `doc_id` タグ付きメトリクスが最大10件のみ含まれること
- [ ] コネクション数の多いドキュメントが上位に来ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)