### PR TITLE
feat: add doc_id routing guard for multi-server deployments

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -4045,6 +4045,7 @@ dependencies = [
  "axum-extra",
  "clap",
  "colored",
+ "crc32fast",
  "cuid",
  "dashmap",
  "ddtrace",

--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -14,6 +14,7 @@ axum = { version = "0.7.4", features = ["ws"] }
 axum-extra = { version = "0.9.2", features = ["typed-header"] }
 clap = { version = "4.3.12", features = ["derive", "env"] }
 colored = "2.0.4"
+crc32fast = "1"  # Custom: doc_id routing guard (matches Go's crc32.ChecksumIEEE)
 cuid = "2.0"
 dashmap = "6.0.1"
 futures = { version = "0.3.28", features = ["std"] }

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 use url::Url;
 use y_sweet::cli::{print_auth_message, print_server_url};
+use y_sweet::server::RoutingConfig;
 use y_sweet::stores::filesystem::FileSystemStore;
 use y_sweet::tracing_setup::init_tracing;
 use y_sweet_core::{
@@ -60,6 +61,16 @@ enum ServSubcommand {
 
         #[clap(long, default_value = "false", env = "Y_SWEET_SKIP_GC")]
         skip_gc: bool,
+
+        /// Total number of y-sweet server instances (for doc_id routing guard).
+        /// Must be set together with Y_SWEET_SERVER_INDEX.
+        #[clap(long, env = "Y_SWEET_SERVER_COUNT")]
+        server_count: Option<u32>,
+
+        /// Zero-based index of this server instance (for doc_id routing guard).
+        /// Must be set together with Y_SWEET_SERVER_COUNT.
+        #[clap(long, env = "Y_SWEET_SERVER_INDEX")]
+        server_index: Option<u32>,
     },
 
     GenAuth {
@@ -184,6 +195,8 @@ async fn main() -> Result<()> {
             prod,
             max_body_size,
             skip_gc,
+            server_count,
+            server_index,
         } => {
             let auth = if let Some(auth) = auth {
                 Some(Authenticator::new(auth)?)
@@ -219,6 +232,34 @@ async fn main() -> Result<()> {
                 print_server_url(auth.as_ref(), url_prefix.as_ref(), addr);
             }
 
+            let routing_config = match (server_count, server_index) {
+                (Some(count), Some(index)) => {
+                    if *count == 0 {
+                        anyhow::bail!("Y_SWEET_SERVER_COUNT must be greater than 0");
+                    }
+                    if *index >= *count {
+                        anyhow::bail!(
+                            "Y_SWEET_SERVER_INDEX ({}) must be less than Y_SWEET_SERVER_COUNT ({})",
+                            index,
+                            count
+                        );
+                    }
+                    tracing::info!(
+                        server_index = index,
+                        server_count = count,
+                        "Routing guard enabled"
+                    );
+                    Some(RoutingConfig {
+                        server_count: *count,
+                        server_index: *index,
+                    })
+                }
+                (None, None) => None,
+                _ => anyhow::bail!(
+                    "Y_SWEET_SERVER_COUNT and Y_SWEET_SERVER_INDEX must be set together"
+                ),
+            };
+
             let token = CancellationToken::new();
 
             let server = y_sweet::server::Server::new(
@@ -230,6 +271,7 @@ async fn main() -> Result<()> {
                 true,
                 *max_body_size,
                 *skip_gc,
+                routing_config,
             )
             .await?;
 
@@ -340,6 +382,7 @@ async fn main() -> Result<()> {
                 false,
                 *max_body_size,
                 *skip_gc,
+                None, // No routing config for single-doc mode
             )
             .await?;
 

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -62,6 +62,12 @@ fn current_time_epoch_millis() -> u64 {
     duration_since_epoch.as_millis() as u64
 }
 
+#[derive(Clone)]
+pub struct RoutingConfig {
+    pub server_count: u32,
+    pub server_index: u32,
+}
+
 #[derive(Debug)]
 pub struct AppError(pub StatusCode, pub anyhow::Error);
 impl std::error::Error for AppError {}
@@ -123,6 +129,7 @@ pub struct Server {
     max_body_size: Option<usize>,
     /// Whether to skip garbage collection in Yrs documents.
     skip_gc: bool,
+    routing_config: Option<RoutingConfig>,
 }
 
 impl Server {
@@ -135,6 +142,7 @@ impl Server {
         doc_gc: bool,
         max_body_size: Option<usize>,
         skip_gc: bool,
+        routing_config: Option<RoutingConfig>,
     ) -> Result<Self> {
         Ok(Self {
             docs: Arc::new(DashMap::new()),
@@ -147,6 +155,7 @@ impl Server {
             doc_gc,
             max_body_size,
             skip_gc,
+            routing_config,
         })
     }
 
@@ -534,6 +543,45 @@ impl Server {
         response
     }
 
+    fn extract_doc_id_from_path(path: &str) -> Option<&str> {
+        let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        match segments.as_slice() {
+            ["d", doc_id, ..] => Some(doc_id),
+            ["doc", "ws", doc_id] => Some(doc_id),
+            ["doc", doc_id, ..] if *doc_id != "new" => Some(doc_id),
+            _ => None,
+        }
+    }
+
+    pub async fn routing_guard_middleware(
+        State(server): State<Arc<Server>>,
+        req: Request,
+        next: Next,
+    ) -> Result<Response, AppError> {
+        if let Some(ref config) = server.routing_config {
+            if let Some(doc_id) = Self::extract_doc_id_from_path(req.uri().path()) {
+                let hash = crc32fast::hash(doc_id.as_bytes());
+                let target_index = hash % config.server_count;
+                if target_index != config.server_index {
+                    warn!(
+                        doc_id = %doc_id,
+                        expected_server = target_index,
+                        actual_server = config.server_index,
+                        "Misdirected request: doc_id not assigned to this server"
+                    );
+                    return Err(AppError(
+                        StatusCode::MISDIRECTED_REQUEST,
+                        anyhow!(
+                            "Document {} is not assigned to this server (expected index {}, this is {})",
+                            doc_id, target_index, config.server_index
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(next.run(req).await)
+    }
+
     pub async fn redact_error_middleware(req: Request, next: Next) -> impl IntoResponse {
         let resp = next.run(req).await;
         if resp.status().is_server_error() || resp.status().is_client_error() {
@@ -560,12 +608,17 @@ impl Server {
                 "/d/:doc_id/ws/:doc_id2",
                 get(handle_socket_upgrade_full_path),
             )
-            .layer(middleware::from_fn(Self::logging_middleware))
-            .layer(OtelAxumLayer::default())
             .with_state(self.clone());
 
-        // Merge extension routes
-        base_routes.merge(crate::server_ext::ext_routes(self))
+        // Merge extension routes and apply middleware stack
+        base_routes
+            .merge(crate::server_ext::ext_routes(self))
+            .layer(middleware::from_fn_with_state(
+                self.clone(),
+                Self::routing_guard_middleware,
+            ))
+            .layer(middleware::from_fn(Self::logging_middleware))
+            .layer(OtelAxumLayer::default())
     }
 
     pub fn single_doc_routes(self: &Arc<Self>) -> Router {
@@ -1271,6 +1324,7 @@ mod test {
             true,
             None,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1311,6 +1365,7 @@ mod test {
             true,
             None,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1355,6 +1410,7 @@ mod test {
                 true,
                 None,
                 false,
+                None,
             )
             .await
             .unwrap(),
@@ -1403,6 +1459,7 @@ mod test {
             true,
             None,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1441,5 +1498,54 @@ mod test {
         assert!(text_ext == ".txt" || text_ext == ".asm");
 
         assert_eq!(get_extension_from_content_type("invalid/type"), ".bin");
+    }
+
+    #[test]
+    fn test_extract_doc_id_from_path() {
+        assert_eq!(
+            Server::extract_doc_id_from_path("/d/abc123/as-update"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/d/abc123/ws/abc123"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/d/abc123/update"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/d/abc123/assets"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/d/abc123/copy"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/doc/ws/abc123"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/doc/abc123/auth"),
+            Some("abc123")
+        );
+        assert_eq!(
+            Server::extract_doc_id_from_path("/doc/abc123/as-update"),
+            Some("abc123")
+        );
+        assert_eq!(Server::extract_doc_id_from_path("/doc/new"), None);
+        assert_eq!(Server::extract_doc_id_from_path("/ready"), None);
+        assert_eq!(Server::extract_doc_id_from_path("/metrics"), None);
+        assert_eq!(Server::extract_doc_id_from_path("/check_store"), None);
+    }
+
+    #[test]
+    fn test_routing_crc32_matches_go() {
+        // Verify crc32fast::hash matches Go's crc32.ChecksumIEEE (same IEEE polynomial).
+        // Values pre-verified against Go: crc32.ChecksumIEEE([]byte("test-doc")) == 1040861620
+        assert_eq!(crc32fast::hash(b"test-doc"), 1040861620);
+        // crc32.ChecksumIEEE([]byte("abc123")) == 3473062748
+        assert_eq!(crc32fast::hash(b"abc123"), 3473062748);
     }
 }


### PR DESCRIPTION
## Summary
- doc_idのCRC32ハッシュベースのルーティングガードを追加。各y-sweetインスタンスが自分の担当外のdoc_idへのリクエストをHTTP 421で拒否する
- 環境変数 `Y_SWEET_SERVER_COUNT`（総台数）と `Y_SWEET_SERVER_INDEX`（0-based自サーバー番号）で制御。未設定時はチェックなし（後方互換）
- Go側の `crc32.ChecksumIEEE` と同一のCRC32 IEEEハッシュを使用（`crc32fast`クレート）

## 変更内容
- `y-sweet/Cargo.toml`: `crc32fast` 依存追加
- `y-sweet/src/server.rs`: `RoutingConfig`構造体、`routing_guard_middleware`、`extract_doc_id_from_path`ヘルパー追加。全doc_idルート（`/d/:doc_id/*`, `/doc/:doc_id/*`）に適用
- `y-sweet/src/main.rs`: CLI引数・環境変数の追加、バリデーション、`Server::new()`への受け渡し

## 動作フロー
1. クライアントが旧URLでy-sweetに接続
2. `routing_guard_middleware`が `crc32(doc_id) % server_count != server_index` を検出
3. HTTP 421 Misdirected Request を返却
4. FEがBEにURL再取得→正しいサーバーに再接続

## Test plan
- [x] `cargo build --all` 通過
- [x] `cargo test --all` 通過（CRC32互換性テスト、パス抽出テスト含む）
- [x] `cargo fmt -- --check` 通過
- [ ] 手動テスト: `Y_SWEET_SERVER_COUNT=2 Y_SWEET_SERVER_INDEX=0` で起動し、担当外doc_idで421が返ることを確認
- [ ] 手動テスト: 環境変数未設定で全リクエストが通ることを確認（後方互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)