### PR TITLE
feat: close misdirected WebSocket sockets on topology change

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -286,9 +286,26 @@ async fn main() -> Result<()> {
                 address = %addr
             );
 
-            tokio::signal::ctrl_c()
-                .await
-                .expect("Failed to install CTRL+C signal handler");
+            // Wait for a shutdown signal. SIGTERM is what container runtimes
+            // (e.g. Kubernetes) send on pod termination / redeploy; handling it
+            // lets graceful shutdown run and close live WebSocket connections so
+            // clients reconnect to the correct node after a topology change.
+            #[cfg(unix)]
+            {
+                let mut sigterm =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                        .expect("Failed to install SIGTERM signal handler");
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {}
+                    _ = sigterm.recv() => {}
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("Failed to install CTRL+C signal handler");
+            }
 
             tracing::info!(
                 message = "Shutting down.",

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
     extract::{
-        ws::{Message, WebSocket},
+        ws::{CloseFrame, Message, WebSocket},
         DefaultBodyLimit, Path, Query, Request, State, WebSocketUpgrade,
     },
     http::{
@@ -67,6 +67,19 @@ pub struct RoutingConfig {
     pub server_count: u32,
     pub server_index: u32,
 }
+
+/// Returns `true` if `doc_id` is assigned to this server under the given routing
+/// config. Mirrors the check in `routing_guard_middleware` and must stay in sync
+/// with the BE-side `loadBalancing` (CRC32 IEEE % server_count).
+fn doc_belongs_to_server(config: &RoutingConfig, doc_id: &str) -> bool {
+    let target_index = crc32fast::hash(doc_id.as_bytes()) % config.server_count;
+    target_index == config.server_index
+}
+
+/// WebSocket close code sent when a live connection is found to be routed to the
+/// wrong server (doc reassigned to another node). In the application-private
+/// range (4000-4999); the FE uses it to trigger an immediate re-routing.
+const WS_CLOSE_MISDIRECTED: u16 = 4421;
 
 #[derive(Debug)]
 pub struct AppError(pub StatusCode, pub anyhow::Error);
@@ -825,6 +838,7 @@ async fn handle_socket_upgrade(
     let awareness = dwskv.awareness();
     let connection_count = dwskv.connection_count();
     let cancellation_token = server_state.cancellation_token.clone();
+    let routing_config = server_state.routing_config.clone();
 
     Ok(ws.on_upgrade(move |socket| {
         let span = tracing::info_span!("ws.session", doc_id = %doc_id);
@@ -835,6 +849,7 @@ async fn handle_socket_upgrade(
             connection_count,
             authorization,
             cancellation_token,
+            routing_config,
         )
         .instrument(span)
     }))
@@ -905,12 +920,21 @@ async fn handle_socket(
     connection_count: Arc<AtomicUsize>,
     authorization: Authorization,
     cancellation_token: CancellationToken,
+    routing_config: Option<RoutingConfig>,
 ) {
     connection_count.fetch_add(1, Ordering::Relaxed);
     let _conn_guard = ConnectionGuard(connection_count);
 
     let (mut sink, mut stream) = socket.split();
     let (send, mut recv) = channel(1024);
+
+    // `doc_id` is moved into `DocConnection` below, so keep a copy for the
+    // periodic routing re-check in the main loop.
+    let routing_doc_id = doc_id.clone();
+    // Signals the sink task to send a Close frame when this server is no longer
+    // responsible for the doc (topology change), so the FE can re-route.
+    let reroute_token = CancellationToken::new();
+    let reroute_token_sink = reroute_token.clone();
 
     info!(
         message = "WebSocket connected",
@@ -960,6 +984,15 @@ async fn handle_socket(
                     }
                     let _ = sink.send(Message::Ping(vec![])).await;
                 }
+                _ = reroute_token_sink.cancelled() => {
+                    let _ = sink
+                        .send(Message::Close(Some(CloseFrame {
+                            code: WS_CLOSE_MISDIRECTED,
+                            reason: "document reassigned to another server".into(),
+                        })))
+                        .await;
+                    break;
+                }
             }
         }
     });
@@ -974,6 +1007,13 @@ async fn handle_socket(
             );
         }
     });
+
+    // Periodically re-evaluate whether this server still owns the doc. The
+    // handshake guard (`routing_guard_middleware`) only rejects new connections;
+    // this catches live connections whose doc has been reassigned (topology
+    // change) and closes them so the FE re-routes to the correct node.
+    let mut routing_ticker = tokio::time::interval(PING_EVERY);
+    routing_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     let mut message_count = 0u64;
     loop {
@@ -1040,6 +1080,22 @@ async fn handle_socket(
                     reason = "server_shutdown"
                 );
                 break;
+            }
+            _ = routing_ticker.tick() => {
+                if let Some(ref config) = routing_config {
+                    if !doc_belongs_to_server(config, &routing_doc_id) {
+                        warn!(
+                            message = "WebSocket closed: document reassigned to another server",
+                            event = "websocket_misdirected_close",
+                            doc_id = %routing_doc_id,
+                            total_messages = %message_count,
+                            reason = "misdirected"
+                        );
+                        // Ask the sink task to send a Close(4421) frame, then exit.
+                        reroute_token.cancel();
+                        break;
+                    }
+                }
             }
         }
     }
@@ -1547,5 +1603,51 @@ mod test {
         assert_eq!(crc32fast::hash(b"test-doc"), 1040861620);
         // crc32.ChecksumIEEE([]byte("abc123")) == 3473062748
         assert_eq!(crc32fast::hash(b"abc123"), 3473062748);
+    }
+
+    #[test]
+    fn test_doc_belongs_to_server() {
+        // From BE_ROUTING_GUARD_SPEC.md: "abc123" -> %2 == 0, %3 == 1.
+        // server_count = 2: abc123 belongs to index 0, not index 1.
+        assert!(doc_belongs_to_server(
+            &RoutingConfig {
+                server_count: 2,
+                server_index: 0,
+            },
+            "abc123"
+        ));
+        assert!(!doc_belongs_to_server(
+            &RoutingConfig {
+                server_count: 2,
+                server_index: 1,
+            },
+            "abc123"
+        ));
+
+        // server_count = 3: 3473062748 % 3 == 2, so abc123 belongs to index 2
+        // only. A connection that was valid under a count=2 topology (index 0)
+        // becomes misdirected after a scale-up to count=3 unless this is index 2
+        // (the topology-change case the live re-check guards against).
+        assert!(doc_belongs_to_server(
+            &RoutingConfig {
+                server_count: 3,
+                server_index: 2,
+            },
+            "abc123"
+        ));
+        assert!(!doc_belongs_to_server(
+            &RoutingConfig {
+                server_count: 3,
+                server_index: 0,
+            },
+            "abc123"
+        ));
+        assert!(!doc_belongs_to_server(
+            &RoutingConfig {
+                server_count: 3,
+                server_index: 1,
+            },
+            "abc123"
+        ));
     }
 }


### PR DESCRIPTION
## 背景

[PR #45](https://github.com/arcterus-jp/y-sweet/pull/45) で doc_id ルーティングガード（`CRC32(doc_id) % server_count != server_index` なら **HTTP 421**）を導入したが、これは **HTTP/WS ハンドシェイク時の新規接続にしか効かない**。

FE からの報告:
- ブラウザは WS ハンドシェイク失敗の HTTP ステータス（421）を読めないため、FE は 421 を判別できず定期再接続で凌いでいた。
- FE は「WS が close になれば自動再接続 → BE ルーティング API で正ノードを再取得 → 再接続」という設計。よって **旧ノードがソケットを閉じれば自己回復する** はずだが、**確立済みソケットがサーバー側で閉じられていなかった**。

### 調査で確定した現状
- `routing_guard_middleware` は接続確立前にしか動かない（新規接続のみ弾ける）。
- `handle_socket` の確立済みセッションには「自分がまだ担当か」を再評価する処理が無い。
- `routing_config` は起動時固定。
- シャットダウンは `ctrl_c()`（SIGINT）のみ捕捉で、k8s の **SIGTERM 未対応** → 再デプロイ時に graceful close が走らない。

## 変更内容

### (A) セッション内ルーティング再判定 + 能動close — `y-sweet/src/server.rs`
- `doc_belongs_to_server(config, doc_id)` ヘルパー追加（ミドルウェアと同じ判定・単体テスト付き）。
- `handle_socket` に `routing_config` を渡し、`PING_EVERY`（20秒）間隔で担当を再評価。担当外を検知したら **Close(4421)** フレームを送出してセッション終了。
- `routing_config = None`（単台運用）では完全に no-op。

### (B) SIGTERM 捕捉による graceful shutdown — `y-sweet/src/main.rs`
- Unix で SIGINT に加え **SIGTERM** も待受。k8s の Pod 終了 / 再デプロイで `cancellation_token` 経由の正規 WS クローズが走る。**「全台同時再デプロイ」シナリオへの直接的な効き手**。

## 検証
- `cargo build --all` ✅
- `cargo test --all` ✅（`test_doc_belongs_to_server` 追加）
- `cargo fmt -- --check` ✅

## FE 側で必要な対応（要合意）
- Close コード **4421**（アプリ定義 private range）を「即再ルーティング」のトリガにするハンドリング。

## 補足
- `(A)` は再起動直後の同一 config プロセスでは発火しない（ローリング更新・設定不整合・将来の動的 config 時の防御）。「全台同時再デプロイ」での直接的な効き手は `(B)`。
- `BE_ROUTING_GUARD_SPEC.md` の検証表で `abc123` の `%3` が `1` とあるが実際は `2`（`3473062748 % 3`）。実コードは `crc32fast` 直接計算のため影響なしだが、ドキュメントの表は別途修正が望ましい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)